### PR TITLE
feat: add conda-like instruction

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,19 @@
+uname_os="$(uname -s)"
+uname_machine="$(uname -m)"
+case "${uname_os}" in
+    Linux*)     machine=linux;;
+    Darwin*)    
+                if [ "$uname_machine" = "x86_64" ]; then
+                    machine=mac;
+                elif [ "$uname_machine" = "arm64" ]; then
+                    machine=m1;
+                fi;;
+    *)          echo "machine ${uname_os} is undefined"; exit 1;;
+esac
+echo ${machine}
+
+export CORE_DIR=$(pwd)
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CORE_DIR/third_party/raisimLib/raisim/${machine}/lib:$CONDA_PREFIX/lib
+export PYTHONPATH=$PYTHONPATH:$CORE_DIR/third_party/raisimLib/raisim/${machine}/lib
+export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$CORE_DIR/third_party/raisimLib/raisim/${machine}
+export RESOURCE_DIR=$CORE_DIR/resource

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ cmake-*/*
 .DS_Store
 .idea/*
 .vscode/*
+
+.cache/*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/raisimLib"]
+	path = third_party/raisimLib
+	url = https://github.com/raisimTech/raisimLib.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required(VERSION 3.10)
-project(ME553_2024)
+project(ME553_2025)
 
 set(CMAKE_CXX_STANDARD 17)
 include(cmake/helper.cmake)
+
+add_subdirectory(third_party/raisimLib)
 
 # exercise
 
@@ -12,6 +14,3 @@ create_executable(rotation_example_euler_angles src/rotation_example_euler_angle
 create_executable(panda_example src/panda.cpp)
 
 # exam
-
-
-

--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# Conda-way of installing the required packages
+
+1. Either use [direnv](https://direnv.net/) or manually activate the content of the `.envrc` file.
+
+2. Create a conda/mamba environment (in all further commands, `mamba` can be replaced with `conda`, if you are using conda):
+
+```bash
+mamba create -n raisim python==3.10.12
+mamba activate raisim
+```
+
+3. Install cxx compiler and related packages:
+
+```bash
+mamba install cxx-compiler ninja cmake eigen ffmpeg minizip
+```
+
+4. Install through cmake:
+
+```bash
+mkdir build && cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DRAISIM_EXAMPLE=ON -DRAISIM_PY=ON -DPYTHON_EXECUTABLE=$(which python) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+make install -j
+```
+
+By now raisim should be accessible and installation will be limited to your conda environment, thus, no need to worry about system-wide installation.
+
+# Examples
+
+You can run example from the `build` directory as executables. For example, to run `panda_example`:
+
+```bash
+cd build
+./panda_example
+```
+
+# Visualizers
+
+All the visualizers are available in the `third_party/raisimLib/{raisimUnity,raisimUnityOpengl}` directories. But you can start them with shortcats in `scripts` directory. The shortcuts also support differnt platforms. Note that `raisimUnityOpengl` is not supported by any Mac OS X, feel free to use `raisimUnity`.
+
+```bash
+bash scripts/raisimUnity.sh
+bash scripts/raisimUnityOpengl.sh
+```
+
+## VSCode setup
+
+VSCode can still be used for C++ project, but the suggestion is to use the following extensions instead of the default C++ ones:
+
+## Known issues
+
+1. While was tested on Mac OS X with Apple Sillicon, some examples failed to build with the same error:
+
+```
+error: no member named 'getSensorSet' in 'raisim::ArticulatedSystem'
+```
+
+Yet you're free to ignore it, snice it does not affect examples from the course.

--- a/scripts/raisimUnity.sh
+++ b/scripts/raisimUnity.sh
@@ -1,0 +1,12 @@
+uname_os="$(uname -s)"
+uname_machine="$(uname -m)"
+case "${uname_os}" in
+    Linux*)     ./third_party/raisimLib/raisimUnityOpengl/linux/raisimUnity.x86_64;;
+    Darwin*)    
+                if [ "$uname_machine" = "x86_64" ]; then
+                    ./third_party/raisimLib/raisimUnity/mac/Contents/MacOS/raisimUnity;
+                elif [ "$uname_machine" = "arm64" ]; then
+                    ./third_party/raisimLib/raisimUnity/m1/RaiSimUnity.app/Contents/MacOS/RaiSimUnity;
+                fi;;
+    *)          echo "machine ${uname_os} is undefined"; exit 1;;
+esac

--- a/scripts/raisimUnityOpengl.sh
+++ b/scripts/raisimUnityOpengl.sh
@@ -1,0 +1,7 @@
+uname_os="$(uname -s)"
+uname_machine="$(uname -m)"
+case "${uname_os}" in
+    Linux*)    ./third_party/raisimLib/raisimUnityOpengl/linux/raisimUnity.x86_64;;
+    Darwin*)    echo "OpenGl Unity is not defined for Mac, please use raisimUnity.sh"; exit 1;;
+    *)          echo "machine ${uname_os} is undefined"; exit 1;;
+esac

--- a/src/panda.cpp
+++ b/src/panda.cpp
@@ -5,17 +5,20 @@
 
 #include "raisim/World.hpp"
 #include "raisim/RaisimServer.hpp"
-
-#define _MAKE_STR(x) __MAKE_STR(x)
-#define __MAKE_STR(x) #x
+#include <cstdlib> 
 
 int main() {
   raisim::World world;
   world.addGround();
-
   raisim::RaisimServer server(&world);
 
-  auto panda = world.addArticulatedSystem(std::string(_MAKE_STR(RESOURCE_DIR)) + "/Panda/panda.urdf");
+  const char* resourceDir = std::getenv("RESOURCE_DIR");
+  if (!resourceDir) {
+    std::cerr << "RESOURCE_DIR environment variable not set" << std::endl;
+    return 1;
+  }
+  
+  auto panda = world.addArticulatedSystem(std::string(resourceDir) + "/Panda/panda.urdf");
 
   server.launchServer();
 

--- a/src/rotation_example_angle_axis.cpp
+++ b/src/rotation_example_angle_axis.cpp
@@ -1,8 +1,6 @@
 #include "raisim/World.hpp"
 #include "raisim/RaisimServer.hpp"
-
-#define _MAKE_STR(x) __MAKE_STR(x)
-#define __MAKE_STR(x) #x
+#include <cstdlib> 
 
 int main() {
   raisim::World world;
@@ -10,11 +8,16 @@ int main() {
 
   raisim::RaisimServer server(&world);
 
-  auto monkey = server.addVisualMesh("monkey", std::string(_MAKE_STR(RESOURCE_DIR)) + "/monkey/monkey.obj");
+  const char* resourceDir = std::getenv("RESOURCE_DIR");
+  if (!resourceDir) {
+    std::cerr << "RESOURCE_DIR environment variable not set" << std::endl;
+    return 1;
+  }
+  auto monkey = server.addVisualMesh("monkey", std::string(resourceDir) + "/monkey/monkey.obj");
   monkey->setColor(0,0,1,1);
   monkey->setPosition(2.5,0,1);
 
-  auto monkey_reference = server.addVisualMesh("monkey_reference", std::string(_MAKE_STR(RESOURCE_DIR)) + "/monkey/monkey.obj");
+  auto monkey_reference = server.addVisualMesh("monkey_reference", std::string(resourceDir) + "/monkey/monkey.obj");
   monkey_reference->setPosition(0,0,1);
 
   double angle = M_PI_2;

--- a/src/rotation_example_euler_angles.cpp
+++ b/src/rotation_example_euler_angles.cpp
@@ -1,20 +1,21 @@
 #include "raisim/World.hpp"
 #include "raisim/RaisimServer.hpp"
 
-#define _MAKE_STR(x) __MAKE_STR(x)
-#define __MAKE_STR(x) #x
-
 int main() {
   raisim::World world;
   world.addGround();
 
   raisim::RaisimServer server(&world);
-
-  auto monkey = server.addVisualMesh("monkey", std::string(_MAKE_STR(RESOURCE_DIR)) + "/monkey/monkey.obj");
+  const char* resourceDir = std::getenv("RESOURCE_DIR");
+  if (!resourceDir) {
+    std::cerr << "RESOURCE_DIR environment variable not set" << std::endl;
+    return 1;
+  }
+  auto monkey = server.addVisualMesh("monkey", std::string(resourceDir) + "/monkey/monkey.obj");
   monkey->setColor(0,0,1,1);
   monkey->setPosition(2.5,0,1);
 
-  auto monkey_reference = server.addVisualMesh("monkey_reference", std::string(_MAKE_STR(RESOURCE_DIR)) + "/monkey/monkey.obj");
+  auto monkey_reference = server.addVisualMesh("monkey_reference", std::string(resourceDir) + "/monkey/monkey.obj");
   monkey_reference->setPosition(0,0,1);
 
   Eigen::Matrix3d xRot, yRot, zRot, rot;


### PR DESCRIPTION
Good afternoon!

Me and @domrachev03 are taking Robot Dynamics course and were interested in extending installation instructions to a single repository and towards local installation instead of system-wise.

Right now it have been tested for linux/macOS users and requires `conda` or `mamba` installed in the system. A little change to the CMakeLists.txt made it possible to install in one-line and simplify the whole process.

We hope it can remove the burden of dependencies installation and let people focus on the course itself.